### PR TITLE
Handle errors without json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+venv
+.mypy_cache

--- a/bulk-upload-python-example/README.md
+++ b/bulk-upload-python-example/README.md
@@ -13,7 +13,11 @@
 
 2. Create a config, you can start from the `config_example.txt`.
 
-3. Make sure [python3](https://www.python.org/downloads/) with [pandas](https://pandas.pydata.org/) is installed.
+3. Make sure [python3](https://www.python.org/downloads/) is installed, and install the additional requirements.
+
+    ```
+    pip install -r requirements.txt
+    ```
 
 4. Run the script:
 

--- a/bulk-upload-python-example/requirements.txt
+++ b/bulk-upload-python-example/requirements.txt
@@ -1,0 +1,3 @@
+numpy>=1.17.4
+pandas>=0.25.3
+requests>=2.22.0


### PR DESCRIPTION
This PR fixes an issue whereby a non-20x response that doesn't include a JSON payload will cause a ValueError to be thrown, resulting in the actual error being hidden.

There are also a couple of extra commits added:
* add a simple .gitignore
* add a requirements.txt (with update in the README), as the README didn't mention the requirement of the `requests` module